### PR TITLE
Update setup_iolt_devices.md remove link to space

### DIFF
--- a/docs/devices/setup_iolt_devices.md
+++ b/docs/devices/setup_iolt_devices.md
@@ -63,7 +63,7 @@ Examples:
 ## Embedding into Gather Town
 
 Invite link: app.gather.town/invite?token=DGRf3bPeSZ-AKx5FHChK
-Link to space: app.gather.town/app/XJWae5GrdpzD5HR7/ac-training-lab-room
+
 Password: `backlog-snowball-protrude` (subject to change in case access needs to be refreshed for some reason)
 
 ![image](https://github.com/user-attachments/assets/0fade265-76f1-471d-a202-ad8c7ae847c1)


### PR DESCRIPTION
Since can't be changed, may as well have the non-expirable invite link.