### PR TITLE
overhaul of device.py for streaming

### DIFF
--- a/src/ac_training_lab/picam/device.py
+++ b/src/ac_training_lab/picam/device.py
@@ -1,92 +1,93 @@
-import logging
-import socket
-import time
+import subprocess
 
-from libcamera import Transform
-from my_secrets import YOUTUBE_STREAM_KEY, YOUTUBE_STREAM_URL
-from picamera2 import Picamera2
-from picamera2.encoders import H264Encoder
-from picamera2.outputs import FfmpegOutput
-
-# Configure logging, useful when running `sudo journalctl -u a1-cam.service -f`,
-# as described in README.
-# Example log: 2025-03-18 15:00:00 - INFO - Starting camera setup...
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
-
-# create a logger with a custom name
-logger = logging.getLogger("picam")
+from my_secrets import STREAM_KEY, STREAM_URL
 
 
-def internet(host="8.8.8.8", port=53, timeout=3):
+def start_stream():
     """
-    Host: 8.8.8.8 (google-public-dns-a.google.com)
-    OpenPort: 53/tcp
-    Service: domain (DNS/TCP)
+    Starts the libcamera -> ffmpeg pipeline and returns two Popen objects:
+      p1: libcamera-vid process
+      p2: ffmpeg process
     """
-    try:
-        socket.setdefaulttimeout(timeout)
-        socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect((host, port))
-        return True
-    except socket.error as ex:
-        print(ex)
-        return False
+    # First: libcamera-vid command
+    libcamera_cmd = [
+        "libcamera-vid",
+        "--inline",
+        "--nopreview",
+        "-t",
+        "0",
+        "--mode",
+        "1536:864",  # A known 16:9 sensor mode
+        "--width",
+        "854",  # Scale width
+        "--height",
+        "480",  # Scale height
+        "--framerate",
+        "15",  # Frame rate
+        "--codec",
+        "h264",  # H.264 encoding
+        "--bitrate",
+        "1000000",  # ~1 Mbps video
+        "-o",
+        "-",  # Output to stdout (pipe)
+    ]
 
+    # Second: ffmpeg command
+    ffmpeg_cmd = [
+        "ffmpeg",
+        # Generate silent audio source
+        "-f",
+        "lavfi",
+        "-i",
+        "anullsrc=channel_layout=stereo:sample_rate=44100",
+        # Handle timestamps/threading
+        "-thread_queue_size",
+        "1024",
+        "-use_wallclock_as_timestamps",
+        "1",
+        # Read H.264 video from pipe
+        "-i",
+        "pipe:0",
+        # Copy the H.264 video directly
+        "-c:v",
+        "copy",
+        # Encode audio as AAC
+        "-c:a",
+        "aac",
+        "-b:a",
+        "128k",
+        "-preset",
+        "fast",
+        "-strict",
+        "experimental",
+        # Output format is FLV, then final RTMP URL
+        "-f",
+        "flv",
+        f"{STREAM_URL}/{STREAM_KEY}",
+    ]
 
-# Wait until internet is connected
-logger.info("Checking for internet")
-while not internet():
-    internet()
-logger.info("Internet connected")
-
-# Initialize the Picamera2 object
-logger.info("Initializing camera")
-picam2 = Picamera2()
-
-# Configure the camera for video capture (set resolution to 1280x720)
-picam2.configure(
-    picam2.create_video_configuration(
-        main={"size": (1280, 720)}, transform=Transform(hflip=1, vflip=1)
+    # Start libcamera-vid, capturing its output in a pipe
+    p1 = subprocess.Popen(
+        libcamera_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
     )
-)
 
-picam2.start()
-logger.info("Camera started")
+    # Start ffmpeg, reading from p1's stdout
+    p2 = subprocess.Popen(ffmpeg_cmd, stdin=p1.stdout, stderr=subprocess.STDOUT)
 
-# Create the ffmpeg command for streaming
-#
-ffmpeg_cmd = [
-    "-b:v 4M",
-    "-f flv",  # Output format for RTMP stream
-    "anullsrc=channel_layout=stereo:sample_rate=48000",
-    f"{YOUTUBE_STREAM_URL}/{YOUTUBE_STREAM_KEY}",  # YouTube RTMP URL and stream key
-]
-ffmpeg_cmd = " ".join(ffmpeg_cmd)
+    # Close p1's stdout in the parent process
+    p1.stdout.close()
 
-# Initialize FfmpegOutput to handle streaming
-ffmpeg_output = FfmpegOutput(ffmpeg_cmd, audio=True)
-h264_encoder = H264Encoder(bitrate=4000000)
+    return p1, p2
 
-# Start the output stream
-picam2.start_recording(encoder=h264_encoder, output=ffmpeg_output)
-logger.info("Streaming started")
 
-try:
-    while True:
-        logger.info("Streaming...")
-        time.sleep(10)
-
-except KeyboardInterrupt:
-    logger.warning("Streaming stopped.")
-
-except Exception as e:
-    logger.error(f"An error occurred: {e}")
-
-finally:
-    # Stop the camera and preview
-    picam2.stop_recording()
-    picam2.stop()
-    logger.info("Camera stopped.")
+if __name__ == "__main__":
+    p1, p2 = start_stream()
+    try:
+        # This will block until ffmpeg stops or the script is interrupted
+        p2.wait()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        # Cleanup: terminate both processes if still running
+        p1.terminate()
+        p2.terminate()

--- a/src/ac_training_lab/picam/device.py
+++ b/src/ac_training_lab/picam/device.py
@@ -8,8 +8,6 @@ from picamera2 import Picamera2
 from picamera2.encoders import H264Encoder
 from picamera2.outputs import FfmpegOutput
 
-# from picamera2 import Preview
-
 # Configure logging, useful when running `sudo journalctl -u a1-cam.service -f`,
 # as described in README.
 # Example log: 2025-03-18 15:00:00 - INFO - Starting camera setup...
@@ -55,16 +53,15 @@ picam2.configure(
     )
 )
 
-# https://chatgpt.com/share/67daf904-3f6c-8006-bb41-559934e82711
-# picam2.start_preview(Preview.NULL)
-
 picam2.start()
 logger.info("Camera started")
 
 # Create the ffmpeg command for streaming
+#
 ffmpeg_cmd = [
     "-b:v 4M",
     "-f flv",  # Output format for RTMP stream
+    "anullsrc=channel_layout=stereo:sample_rate=48000",
     f"{YOUTUBE_STREAM_URL}/{YOUTUBE_STREAM_KEY}",  # YouTube RTMP URL and stream key
 ]
 ffmpeg_cmd = " ".join(ffmpeg_cmd)
@@ -79,6 +76,7 @@ logger.info("Streaming started")
 
 try:
     while True:
+        logger.info("Streaming...")
         time.sleep(10)
 
 except KeyboardInterrupt:

--- a/src/ac_training_lab/picam/my_secrets_example.py
+++ b/src/ac_training_lab/picam/my_secrets_example.py
@@ -1,2 +1,2 @@
-YOUTUBE_STREAM_URL = "your_stream_url_here"  # e.g., rtmp://a.rtmp.youtube.com/live2
-YOUTUBE_STREAM_KEY = "your_stream_key_here"
+STREAM_URL = "your_stream_url_here"  # e.g., rtmp://a.rtmp.youtube.com/live2
+STREAM_KEY = "your_stream_key_here"


### PR DESCRIPTION
https://chatgpt.com/share/67db7c8d-c1d8-8006-b825-97f48f0d559f

Misc. transcripts (variable quality of transcripts, too):
- https://chatgpt.com/share/67db7e3f-bc3c-8006-8662-d2c4ca0fda9a
- https://chatgpt.com/share/67db7e4f-4680-8006-b43d-3e50162befed
- https://chatgpt.com/share/67db7e81-a210-8006-bab6-5ad954c6898a
- https://chatgpt.com/share/67db7e99-a32c-8006-84f8-489a340002fc
- https://chatgpt.com/share/67db7eb0-195c-8006-b75c-940bfaa5f2fb

Other resources:
- https://superuser.com/questions/1689858/set-a-audio-bitrate-cap-in-ffmpeg
- https://forums.raspberrypi.com/viewtopic.php?t=321567
- https://superuser.com/questions/945413/how-to-consider-bitrate-maxrate-and-bufsize-of-a-video-for-web
- https://trac.ffmpeg.org/wiki/Limiting%20the%20output%20bitrate
- https://superuser.com/questions/1305380/how-to-use-ffmpeg-t-when-using-a-live-youtube-source-with-youtube-dl
- https://stackoverflow.com/questions/67089528/how-to-get-ffmpeg-configuration-similar-to-that-of-youtube-for-480p-and-1080p-vi
- https://www.reddit.com/r/raspberry_pi/comments/3vgza3/i_want_to_livestream_a_720p_or_480p_video_stream/
- https://www.reddit.com/r/frigate_nvr/comments/18dyjkn/timestamps_are_unset_in_a_packet_for_stream_0/
- https://superuser.com/questions/1226305/ffmpeg-warning-timestamps-are-unset-in-a-packet-when-converting-h264-to-mp4