### PR TITLE
Pioreactor HTTP and requirements.txt

### DIFF
--- a/src/ac_training_lab/pioreactor/on_reactor.py
+++ b/src/ac_training_lab/pioreactor/on_reactor.py
@@ -26,7 +26,8 @@ Author: Enrui (Edison) Lin
 
 
 # This should reflect the domain_alias in the PioReactor Configuration
-HTTP = "http://piobio.local/api"
+# HTTP = "http://piobio.local/api"
+HTTP = "http://pioreactor01.local/api"
 
 automation_name = None
 stirring_target_rpm = None

--- a/src/ac_training_lab/pioreactor/requirements.txt
+++ b/src/ac_training_lab/pioreactor/requirements.txt
@@ -1,0 +1,1 @@
+paho-mqtt


### PR DESCRIPTION
technically requirements.txt with paho-mqtt not needed since already installed on pioreactor by default