### PR TITLE
Update copilot-setup-steps.yml add prefect mintlify

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,4 +19,5 @@ jobs:
           pip install -e .
           pip install tox pre-commit
           pre-commit run --all-files
+          npx mint-mcp add docs.prefect.io
           # pre-commit install # don't install, since this has been a source of issues


### PR DESCRIPTION
Only for docs that are hosted on mintlify (i.e., not for any of the docs I develop), but Prefect happens to be hosted on mintlify. It would be nice to know if there's something similar or something I'd migrate to in terms of docs from sphinx/readthedocs/etc.