### PR TITLE
Enhance instructions for using checkerboard images in apriltag_demo.ipynb

### DIFF
--- a/src/ac_training_lab/apriltag_demo/apriltag_demo.ipynb
+++ b/src/ac_training_lab/apriltag_demo/apriltag_demo.ipynb
@@ -600,9 +600,9 @@
     "id": "a9e2d0f8"
    },
    "source": [
-    "Run the cell below to either  use the pre-supplied ones (set `test=True` at top) or upload your own checkerboard images (set `test=False` at top). If you're using your own checkerboard images and running outside of Google Colab, insert your images in the `image_dir` folder (by default `./checkerboard_images`). \n",
+    "If you set `test=True` at the top, it will use pre-supplied \"dummy\" images for a specific laptop webcam. This is just to show you a self-contained example. If you plan to use this in practice, set `test=False` at the beginning and upload your own captured checkerboard images per the instructions above. In this case, running the cell below will provide you with a button to upload your images. If you're running this notebook outside of Google Colab and `test=False`, insert your images in the `image_dir` folder (by default `./checkerboard_images`).\n",
     "\n",
-    "> NOTE: Camera intrinsics greatly affect detection accuracy. The pre-supplied checkerboard images in the ZIP file were captured using a specific laptop webcam. To use this in practice, you need to either capture your own checkerboard images or trust camera intrinsics for your specific camera published by the manufacturer or via forums, which might not be available."
+    "> NOTE: Camera intrinsics greatly affect detection accuracy. The pre-supplied checkerboard images in the ZIP file were captured using a specific laptop webcam and should not be used directly in any real workflows, since the camera intrinsics are likely to be very different. To use this in practice, you need to either capture your own checkerboard images or check if the camera intrinsics for your specific camera are listed (e.g., published by the manufacturer or posted on forums)."
    ]
   },
   {


### PR DESCRIPTION
- Clarified the usage of pre-supplied "dummy" images versus user-uploaded images.
- Emphasized the importance of capturing own checkerboard images for accurate camera intrinsics.
- Updated notes to discourage reliance on pre-supplied images for real workflows.